### PR TITLE
fix the bug :)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -28,12 +28,18 @@ export function startServer() {
     app.get("/async-local-storage", async (req, res) => {
       const dataFromClient = req.headers["data"];
 
+      const theDomain = domain.create();
+
+      theDomain.enter();
+
       someAsyncStorage.run({ dataFromClient }, async () => {
         const theAsyncData = await anAsyncFunctionThatReturnsFromContext();
 
         res.header("data", theAsyncData);
         res.end();
       });
+
+      theDomain.exit();
     });
 
     app.listen(3000, () => {

--- a/server.ts
+++ b/server.ts
@@ -35,11 +35,11 @@ export function startServer() {
       someAsyncStorage.run({ dataFromClient }, async () => {
         const theAsyncData = await anAsyncFunctionThatReturnsFromContext();
 
+        theDomain.exit();
+        
         res.header("data", theAsyncData);
         res.end();
       });
-
-      theDomain.exit();
     });
 
     app.listen(3000, () => {


### PR DESCRIPTION
the problem is that you are checking the value of `process.domain` while not inside `domain.enter()`. I guess in this case there are no guarantees that it will not have garbage from other sessions. Of course all of the domain related code can be deleted once experiment is merged.